### PR TITLE
Change Gemfile source to secure version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 group :test do


### PR DESCRIPTION
`source :rubygems` has been [deprecated](https://github.com/bundler/bundler/commit/d30026e) due to security issues.
