### PR TITLE
Change Redis dependency to 3.x

### DIFF
--- a/redis_scripts.gemspec
+++ b/redis_scripts.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_runtime_dependency 'redis', '~> 3.0.0'
+  gem.add_runtime_dependency 'redis', '~> 3.0'
   gem.add_development_dependency 'temporaries', '~> 0.3.0'
   gem.add_development_dependency 'ritual', '~> 0.4.1'
 end


### PR DESCRIPTION
We should be dependent on 3.x, not 3.0.x
